### PR TITLE
Pin versions and add missing deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-praw
-transformers
-torch
-flask
-python-dotenv
+praw==7.7.1
+transformers==4.33.2
+torch==2.0.1
+flask==2.3.2
+python-dotenv==1.0.0
+apscheduler==3.10.4
+diffusers==0.20.2


### PR DESCRIPTION
## Summary
- pin all dependency versions
- add `apscheduler` and `diffusers` to requirements

## Testing
- `python test.py` *(fails: ModuleNotFoundError for `torch`)*

------
https://chatgpt.com/codex/tasks/task_e_6848bd6d15488326b6bec33ead432b99